### PR TITLE
FINUFFTv2 compatibility done; few other path and tweaks to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ There are a couple of examples in [examples/](examples/), tests can be run with 
 pip install .
 ```
 
+## Running local tests
+
+From the `fsinc` top directory, make sure you have `pytest` and
+`pytest-benchmark` installed in your
+python enviroment, then do:
+```sh
+PYTHONPATH=fsinc pytest
+```
+The path is needed so local `fastgl` module is seen,
+apparently (please help fix this).
+To do a subset of tests, eg just 1d ones, use:
+```sh
+PYTHONPATH=fsinc pytest -s -k "sinc1d"
+```
+Here the `-s` is if you want to insert print statements into the tests
+and see the outputs.
+
+
+
 ## Building docs
 
 Set up the environment in [doc/environment.yml](doc/environment.yml), install enough of tex-live and run `make` to generate `pdf` using `pandoc`.

--- a/fsinc/fsinc_1d_nu.py
+++ b/fsinc/fsinc_1d_nu.py
@@ -22,7 +22,7 @@ def sinc1d_interp_nu2(x, s, xp, B = 3.):
   print('mean bandlimit:', 1./np.max(np.diff(x)))
   x, xp = fsinc.zero_offset(x, xp)
 
-  B = np.float(B)
+  B = float(B)
   print('bandlimit:', B)
 
   ws = jacobi_1d(x)
@@ -56,7 +56,7 @@ def sinc1d_interp_nu3(x, s, xp, B = 3.):
   print('mean bandlimit:', 1./np.max(np.diff(x)))
   x, xp = fsinc.zero_offset(x, xp)
 
-  B = np.float(B)
+  B = float(B)
   print('bandlimit:', B)
 
   ws = (np.pi / B) / sincsq1d(B * x, np.ones(x.shape), B * x) # use sinc^2 weights

--- a/fsinc/fsinc_2d.py
+++ b/fsinc/fsinc_2d.py
@@ -1,5 +1,5 @@
 import numpy as np
-import finufftpy as nufft
+import finufft as nufft
 from . import fastgl
 
 def sinc2d(x, y, s, xp, yp, norm = False, eps = 1.e-6):
@@ -37,18 +37,14 @@ def sinc2d(x, y, s, xp, yp, norm = False, eps = 1.e-6):
   print('calculate Legendre-Gauss weights (using fastgl), nodes:', nx, "x", ny)
   xx, yy, ww = fastgl.lgwt2d(nx, ny)
 
-  # Fwd FT
-  h = np.zeros(xx.shape, dtype = np.complex128) # signal at xx (G-L nodes)
-  status = nufft.nufft2d3(x, y, s, -1, eps, xx, yy, h, debug = 0, spread_debug = 0, upsampfac = 1.25)
-  assert status == 0
+  # Fwd FT for signal at xx (G-L nodes)
+  h = nufft.nufft2d3(x, y, s.astype('complex128'), xx.astype('float64'), yy.astype('float64'), isign=-1, eps=eps, upsampfac = 1.25)
 
   # integrate signal using G-L quadrature
   ws = (1./4.) * h * ww
 
-  # Inv FT
-  sp = np.zeros(xp.shape, dtype = np.complex128) # signal at xx
-  status = nufft.nufft2d3(xx, yy, ws, 1, eps, xp, yp, sp, debug = 0, spread_debug = 0, upsampfac = 1.25)
-  assert status == 0
+  # Inv FT for signal at xx
+  sp = nufft.nufft2d3(xx.astype('float64'), yy.astype('float64'), ws, xp, yp, isign=1, eps=eps, upsampfac = 1.25)
 
   if np.all(np.isreal(s)):
     return sp.real
@@ -90,18 +86,14 @@ def sincsq2d(x, y, s, xp, yp, norm = False, eps = 1.e-6):
   print('calculate Legendre-Gauss weights (using fastgl), nodes:', 2*nx, "x", 2*ny)
   xx, yy, ww = fastgl.lgwt_tri_2d(nx, ny)
 
-  # Fwd FT
-  h = np.zeros(xx.shape, dtype = np.complex128) # signal at xx (G-L nodes)
-  status = nufft.nufft2d3(x, y, s, -1, eps, xx, yy, h, debug = 0, spread_debug = 0, upsampfac = 1.25)
-  assert status == 0
+  # Fwd FT for signal at xx (G-L nodes)
+  h = nufft.nufft2d3(x, y, s.astype('complex128'), xx.astype('float64'), yy.astype('float64'), isign=-1, eps=eps, upsampfac = 1.25)
 
   # integrate signal using G-L quadrature
   ws = (1./16.) * h * ww
 
-  # Inv FT
-  sp = np.zeros(xp.shape, dtype = np.complex128) # signal at xx
-  status = nufft.nufft2d3(xx, yy, ws, 1, eps, xp, yp, sp, debug = 0, spread_debug = 0, upsampfac = 1.25)
-  assert status == 0
+  # Inv FT for signal at xx
+  sp = nufft.nufft2d3(xx.astype('float64'), yy.astype('float64'), ws, xp, yp, isign=1, eps=eps, upsampfac = 1.25)
 
   if np.all(np.isreal(s)):
     return sp.real

--- a/fsinc/fsinc_2d_nu.py
+++ b/fsinc/fsinc_2d_nu.py
@@ -34,7 +34,7 @@ def sinc2d_interp_nu2(x, y, s, B, xp, yp):
   x, xp = fsinc.zero_offset(x, xp)
   y, yp = fsinc.zero_offset(y, yp)
 
-  B = np.float(B)
+  B = float(B)
   print("calcuating jacobian (2d)")
   # ws = jacobian_2d_sk(x, y)
   # ws = jacobi_2d_approx(x, y)
@@ -112,7 +112,7 @@ def sinc2d_interp_nu3(x, y, s, B, xp, yp):
   x, xp = fsinc.zero_offset(x, xp)
   y, yp = fsinc.zero_offset(y, yp)
 
-  B = np.float(B)
+  B = float(B)
   # print("calcuating jacobian (2d)")
   # ws = jacobian_2d_sk(x, y)
   # ws = jacobi_2d_approx(x, y)

--- a/fsinc/jacobian.py
+++ b/fsinc/jacobian.py
@@ -16,7 +16,7 @@ def jacobian_2d_ktree(x, y):
   d = np.vstack((x,y)).T
   t = cKDTree(d)
 
-  (w, i) = t.query(d, [2], n_jobs = -1)
+  (w, i) = t.query(d, [2], workers = -1)
   return w.squeeze()
 
 @numba.njit(parallel = True, cache = True)
@@ -36,7 +36,7 @@ def jacobian_2d_sk(x, y):
   d = np.vstack((x,y)).T
   print("jacobian:", d.shape)
   from sklearn.neighbors import NearestNeighbors, KNeighborsTransformer
-  nbrs = NearestNeighbors(n_neighbors = 2, n_jobs = -1).fit(d)
+  nbrs = NearestNeighbors(n_neighbors = 2, workers = -1).fit(d)
   w, ii = nbrs.kneighbors(d, 2)
 
   return w[:,1].squeeze()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 scipy
 numba
 matplotlib
-finufftpy
+finufft
 pytest
 pytest-benchmark

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
     author_email='gauteh@met.no',
     description='Implementation of fast sinc-transform based on https://github.com/hannahlawrence/sinctransform',
     packages=find_packages(),
-    install_requires=['numpy', 'numba', 'scipy', 'matplotlib', 'finufftpy'],
+    install_requires=['numpy', 'numba', 'scipy', 'matplotlib', 'finufft'],
 )
 

--- a/tests/sinc1d_test.py
+++ b/tests/sinc1d_test.py
@@ -22,7 +22,7 @@ def test_sinc1d_same():
 
   s = np.random.uniform(-100, 100, x.size)
 
-  sp = fsinc.sinc1d(x, s, x, True)
+  sp = fsinc.sinc1d(x, s, x, norm=True)
   dp = sinc1d(x, s, x)
   np.testing.assert_allclose(sp, dp, atol = 2e-3)
 
@@ -32,7 +32,7 @@ def test_sinc1d_different_targets():
 
   s = np.sin(x)
 
-  sp = fsinc.sinc1d(x, s, xp, True)
+  sp = fsinc.sinc1d(x, s, xp, norm=True)
   dp = sinc1d(x, s, xp)
   np.testing.assert_allclose(sp, dp, atol = 3e-3)
 
@@ -42,7 +42,7 @@ def test_sinc1d_nu_to_u():
 
   s = np.sin(x)
 
-  sp = fsinc.sinc1d(x, s, xp, True)
+  sp = fsinc.sinc1d(x, s, xp, norm=True)
   dp = sinc1d(x, s, xp)
   np.testing.assert_allclose(sp, dp, atol = 2e-3)
 
@@ -52,6 +52,6 @@ def test_sinc1d_nu_to_nu():
 
   s = np.sin(x)
 
-  sp = fsinc.sinc1d(x, s, xp, True)
+  sp = fsinc.sinc1d(x, s, xp, norm=True)
   dp = sinc1d(x, s, xp)
   np.testing.assert_allclose(sp, dp, atol = 2e-3)


### PR DESCRIPTION
Dear Gaute,

Finally (after 2 years...) I updated your package to work again, using FINUFFT v2 (which broke the interfaces).  Please check it works your end, and pull this in if you approve.

There are a couple of problems:
* the unit tests are stochastic, ie, they sometimes fail due to random-number generation
* it was very frustrating to get the `fastgl` module be seen inside the eg the `fsinc_1d.py` module. In the end I can only run tests if I add to PYTHONPATH as I describe in README update. I don't know Py enough to understand how to fix this.
* I had to enforce a bunch of types to be float64 as they go into FINUFFT. I don't understand why - it appears like xx and ww coming out of fastgl should be float64, but if I omit the conversion then FINUFFT gets upset.

Anyway, it works now (most of the time, due to stochastic!).   I hope it's still useful to you.

Thanks, Alex